### PR TITLE
dev : API 개발 고급 - 지연 로딩과 조회 성능 최적화

### DIFF
--- a/Spring_JPA-Dev-1/build.gradle
+++ b/Spring_JPA-Dev-1/build.gradle
@@ -36,7 +36,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0'
+	// implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta'
+
 
 }
 

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop;
 
+import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class JpashopApplication {
@@ -9,5 +11,22 @@ public class JpashopApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(JpashopApplication.class, args);
 	}
+
+	@Bean // /api/v1/simple-orders 연관
+	Hibernate5JakartaModule hibernate5JakartaModule() {
+		return new Hibernate5JakartaModule(); // 초기화된 프록시 객체만 노출하고 초기화 되지 않은 프록시 객체는 null 처리
+		// 이때 초기화된 프록시 객체가 요청이 필요한 객체와 양방향 관계일 경우 무한 루프가 빠진다.
+		// 따라서 한쪽에 @JsonIgnore 설정이 필요하다 !
+	}
+
+//	@Bean // /api/v1/simple-orders 연관
+//	Hibernate5JakartaModule hibernate5Module() {
+//		Hibernate5JakartaModule hibernate5Module= new Hibernate5JakartaModule();
+//
+//		// 강제 지연 로딩 설정 : 양방향 연관관계를 계속 로딩하여 무한 루프가 빠지므로 한쪽에 @JsonIgnore 설정이 필요하다.
+//		hibernate5Module.configure(Hibernate5JakartaModule.Feature.FORCE_LAZY_LOADING, true);
+//
+//		return hibernate5Module;
+//	}
 
 }

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,0 +1,104 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderSearch;
+import jpabook.jpashop.domain.OrderStatus;
+import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryRepository;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Order
+ * Order -> Member = 다대일 관계
+ * Order -> Delivery = 일대일 관계
+ */
+@RestController
+@RequiredArgsConstructor
+public class OrderSimpleApiController {
+
+    private final OrderRepository orderRepository;
+    private final OrderSimpleQueryRepository orderSimpleQueryRepository;
+
+    /**
+     * V1. 엔티티 직접 노출
+     * - Hibernate5Module을 등록하면 LAZY = null 처리된다.
+     * - 양방향 관계일 경우 무한 루프에 빠지므로 한쪽에 @JsonIgnore을 설정해줘야 한다.
+     *   - Order의 Member가 프록시 객체인데 JSON으로 응답할 때 기본적으로 이 프록시 객체를 JSON으로 어떻게 직렬화하는지 모른다.
+     *   - 따라서, 이때 Member를 조회하는 쿼리가 나가게 되고 무한 루프가 수행된다.
+     *   - 그래서 Hibernate5Module을 등록해 LAZY = null로 처리해야 한다.
+     */
+    @GetMapping("/api/vi/simple-orders")
+    public List<Order> ordersV1() {
+        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+        for (Order order : all) {
+            order.getMember().getName(); // LAZY 강제 초기화 => 예외 발생 안함 ! why? Open Session in View(OSIV) 때문에
+            order.getDelivery().getAddress(); // LAZY 강제 초기화 => 예외 발생 안함 ! why? Open Session in View(OSIV) 때문에
+        } // 원래는 LazyInitializationException이 발생하는게 정상이지만 OSIV로 인해 발생하지 않음
+        return all;
+    }
+
+    /**
+     * V2. 엔티티를 조회해서 DTO로 변환(fetch join 사용 X)
+     * - 단점 : 지연로딩으로 인해 N번 호출
+     */
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> orderV2() {
+
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+
+        return orders.stream()
+                .map(SimpleOrderDto::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * V3. 엔티티를 조회해서 DTO로 변환(fetch join 사용 O)
+     * - fetch join으로 쿼리를 1번 호출 !
+     */
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> ordersV3() {
+
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+
+        return orders.stream()
+                .map(SimpleOrderDto::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * V4. JPA에서 DTO로 바로 조회
+     * - 쿼리 1번 호출
+     * - select 절에서 원하는 데이터만 선택해서 조회할 수 있다.
+     */
+    @GetMapping("/api/v4/simple-orders")
+    public List<OrderSimpleQueryDto> ordersV4() {
+        return orderSimpleQueryRepository.findOrderDtos();
+    }
+
+    @Data
+    static class SimpleOrderDto {
+
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+
+        public SimpleOrderDto(Order order) {
+            this.orderId = order.getId();
+            this.name = order.getMember().getName(); // LAZY 초기화
+            this.orderDate = order.getOrderDate();
+            this.orderStatus = order.getStatus();
+            this.address = order.getDelivery().getAddress(); // LAZY 초기화
+        }
+    }
+}

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,6 +14,7 @@ public class Delivery {
    @Column(name = "delivery_id")
    private Long id;
 
+   @JsonIgnore
    @OneToOne(mappedBy = "delivery", fetch = FetchType.LAZY)
    private Order order;
 

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/domain/Member.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +22,7 @@ public class Member {
     @Embedded
     private Address address;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member") // 양방향 매핑
     private List<Order> orders = new ArrayList<>();
 

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -101,4 +101,14 @@ public class OrderRepository {
         return query.getResultList();
     }
 
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery(
+                "select o from Order o" +
+                        " join fetch o.member m" +
+                        " join fetch o.delivery d", Order.class)
+                .getResultList();
+    } // fetch join으로 member와 delivery는 조회된 상태이므로 지연로딩이 발생하지 않는다.
+
+
+
 }

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
@@ -1,0 +1,25 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderSimpleQueryDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    public OrderSimpleQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
@@ -1,0 +1,21 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderSimpleQueryRepository {
+
+    private final EntityManager em;
+
+    public List<OrderSimpleQueryDto> findOrderDtos() {
+        return em.createQuery(
+                "select new jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto(o.id, m.name, o.orderDate, o.status, d.address)" +
+                        " from Order o" + " join o.member m" + " join o.delivery d", OrderSimpleQueryDto.class)
+                .getResultList();
+    }
+}

--- a/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/service/OrderService.java
+++ b/Spring_JPA-Dev-1/src/main/java/jpabook/jpashop/service/OrderService.java
@@ -15,9 +15,11 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 /**
- * @Transactional(readOnly = true)을 안 써도 Lazy 로딩은 유지된다.
- * 하지만 트랜잭션이 없으면 지연 로딩 중에 예외(트랜잭션 설정을 안해서 프록시 객체가 없어 DB와 연결이 끊김)가 나기 때문에,
- * 조회 메서드에도 @Transactional(readOnly = true)를 쓰는 게 안전하다. */
+ @Transactional(readOnly = true)를 명시하지 않아도
+ → 프록시 객체는 생성되고,
+ → 엔티티의 Lazy 로딩 설정도 유지된다.
+ 그러나 중요한 건 "트랜잭션의 범위 안에서만 Lazy 로딩이 안전하게 작동한다"는 점 => 예외가 발생함
+ */
 public class OrderService {
 
     private final MemberRepository memberRepository;

--- a/Spring_JPA-Dev-1/src/main/resources/application.yml
+++ b/Spring_JPA-Dev-1/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     properties:
       hibernate:
 #        show_sql: true => System.out에 하이버네이트 실행 SQL을 남긴다.
-#        format_sql: true
+         format_sql: true
 
   thymeleaf: # default이지만 이런 설정이 있다는 것을 알기 위해 작성함
     prefix: classPath:/templates/


### PR DESCRIPTION
API 개발 고급 - 지연 로딩과 조회 성능 최적화
1. 엔티티를 직접 노출해서 응답
2. 엔티티를 DTO로 변환해서 응답
3. 엔티티를 DTO로 변환해서 응답 - fetch join으로 조회 성능 최적화
4. JPA에서 DTO로 바로 조회 - fetch join으로 조회 성능 최적화